### PR TITLE
Fix falling obstacles after exit

### DIFF
--- a/game.js
+++ b/game.js
@@ -50,7 +50,10 @@ function create () {
     player.body.setCollideWorldBounds(true);
     player.body.setGravityY(300);
 
-    obstacles = this.physics.add.group();
+    obstacles = this.physics.add.group({
+        allowGravity: false,
+        immovable: true
+    });
 
     this.physics.add.collider(player, ground);
     this.physics.add.collider(player, obstacles, hitObstacle, null, this);
@@ -101,7 +104,7 @@ function update () {
 
         obstacles.getChildren().forEach(function(obstacle) {
             if (obstacle.x < -obstacle.width) {
-                obstacles.remove(obstacle, true, true);
+                obstacle.destroy();
             }
         });
 


### PR DESCRIPTION
## Summary
- prevent gravity from affecting obstacles
- ensure destroyed obstacles don't linger after leaving screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840052370e08328826c4e1112109a82